### PR TITLE
Bug fixes associated with three player game

### DIFF
--- a/cards.py
+++ b/cards.py
@@ -18,6 +18,12 @@ class Hand:
         self.known_voids = set()            # set of suits we know we don't have
         self.number_of_unknown_cards = 4    # we always start with four cards
 
+    def is_empty(self):
+        """
+        Returns true if this player has no cards at all.
+        """
+        return not self.known_cards and self.number_of_unknown_cards == 0
+
     def show(self, is_next_player: bool):
         """
         Write to stdout a representation of the hand
@@ -214,10 +220,12 @@ class Cards:
     of players. There are four cards per player, and the same
     number of suits as players.
     """
-
     def __init__(self, number_of_players):
         self.hands = [Hand() for _ in range(number_of_players)]
     
+    def is_empty(self, player):
+        return self.hands[player].is_empty()
+
     def number_of_players(self):
         return len(self.hands)
 
@@ -366,12 +374,12 @@ class Cards:
 
         return moves
 
-    def position(self) -> int:
+    def position(self, last_player: int) -> int:
         """
         Returns a representation of the current set of hands as an integer,
         so we can test whether the position repeats.
         """
-        pos = 0
+        pos = last_player
         number_of_players = len(self.hands)
         for hand in self.hands:
             pos = hand.position(pos, number_of_players)
@@ -403,6 +411,17 @@ class Cards:
   
         # genuinely unforced
         return False, False
+    
+    def next_player(self, this_player: int) -> int:
+        """
+        Finds the next player who is able to move (has any cards)
+        """
+        n = self.number_of_players()
+        p = (this_player + 1) % n
+        while self.hands[p].is_empty():
+            p = (p + 1) % n
+            assert p != this_player, "At least one player must have some cards"
+        return p            
 
 def _not_legal(verbose, message) -> bool:
     if verbose:

--- a/game.py
+++ b/game.py
@@ -15,6 +15,10 @@ def play(players) -> int:
     while True:
         for i, p in enumerate(players):
             cards.show(i)
+            if cards.is_empty(i):
+                print(f"Player {i} must skip as they have no cards")
+                continue
+
             other, suit = p.next_move(i, cards, history)
             print(f"Player {i} requests suit {suit} from player {other}")
             if players[other].has_card(other, i, suit, cards, history):
@@ -29,7 +33,7 @@ def play(players) -> int:
                 return winner
 
             # if a position repeats, it forces a draw
-            position = cards.position()
+            position = cards.position(i)
             if position in history:
                 return -1
             history.add(position)

--- a/player.py
+++ b/player.py
@@ -116,10 +116,9 @@ class CleverPlayer(Player):
         Like next_move, but it also returns a result, which says what 
         the final best-case result is as a result of this move.
         """
-        # try all the legal moves. If there are none, it is stalemate
+        # try all the legal moves. (We know there must be some, as the player has some cards)
         legal_moves = cards.legal_moves(this)
         assert len(legal_moves) > 0
-        next_player = (this + 1) % cards.number_of_players()
         draw = None
         lose = None
         immediate_lose = None
@@ -142,7 +141,7 @@ class CleverPlayer(Player):
                 continue
             
             # if this move results in a draw, remember it
-            position = copy_cards.position()
+            position = copy_cards.position(this)
             immediate_draw = position in history
             if immediate_draw:
                 draw = (other, suit, -1)
@@ -152,6 +151,7 @@ class CleverPlayer(Player):
                 continue        # stop looking if we have hit a draw
 
             # Allow the next player to play their best move
+            next_player = copy_cards.next_player(this)
             _, _, next_winner = self._evaluate_move(next_player, copy_cards, copy_history)
             
             # If this results in a win for us, play this move


### PR DESCRIPTION
Still does not complete the three player game, but the two-player one now runs correctly and the three-player game does not assert -- it just doesn't come back. This patch contains the following fixes:

* Handle the case when one player runs out of cards. (They skip any subsequent turns.)
* Add the player number to the position when checking for repeated-position draw.