### PR TITLE
Speed up game by caching

### DIFF
--- a/game.py
+++ b/game.py
@@ -35,5 +35,6 @@ def play(players) -> int:
             # if a position repeats, it forces a draw
             position = cards.position(i)
             if position in history:
+                cards.show(-1)
                 return -1
             history.add(position)


### PR DESCRIPTION
We cache the results and best moves for each deck of hands. We use the symmetries defined in position: in other words we treat the same positions that merely permute the suits or rotate the players.

The effect on performance is dramatic. Previously the three player game took upwards of an hour to complete even with just ten levels of lookahead and one level for deciding whether or not we have a hand. Now we can run with effectively unlimited lookahead for both (1000 levels) and it takes less than half a minute.

The result is always a win for player 1 in the three player game