### PR TITLE
Extended shake_down to handle groups of cards

### DIFF
--- a/player.py
+++ b/player.py
@@ -1,8 +1,9 @@
 from abc import ABC
 from typing import List, Tuple, Set
 from random import randrange
+from collections import Counter
 from copy import deepcopy
-from cards import Cards
+from cards import Cards, Hand
 from game import play
 from time import perf_counter
 import numpy as np


### PR DESCRIPTION
If there are multiple hands that refer to the same group of cards, for example two hands that have the same exclusion list, this group can be treated as a unit when testing whether the missing cards match the holes for them.

This fixes some of the warnings when running the four player game.