### PR TITLE
Be more careful about caching draws

### DIFF
--- a/cards.py
+++ b/cards.py
@@ -670,6 +670,8 @@ class Cards:
 
         * Rotation of players (e.g. player 0 -> 1, 1 -> 2 and 2 -> 0)
         * Permutation of suits (e.g. swapping any two suits)
+
+        Note that position is always an integer greater or equal to zero.
         """
         # Handle rotation of players by always starting from the last
         # player. This also means we do not need to encode the player


### PR DESCRIPTION
There are two reasons why a given position may result in a forced draw:

1. Because there are no better options for any of the players from that position than to force a draw
2. Because there happens to be the same position somewhere in the history of the current hand which matches some future position given all players' best play

Basically, a draw is the result of a repeating loop of game play. If the whole of the loop is in the future, and all players are playing optimally, we know that the draw must be forced. It is a type one draw. If the loop spans both past and future, it is possible that we are currently in the loop only as part of evaluating some suboptimal branch. Thus it is a type two draw.

We now only cache type one draws. Type two draws are treated as a temporary state, not necessarily always associated with the given position.

There is no impact on any of the standard two and three player games tested here. However, it is more theoretically correct to play this way, and the impact on runtime is minimal.